### PR TITLE
style: add flex-wrap to nav-menu

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -15,4 +15,5 @@
   align-items: center;
   gap: 1em;
   margin: 0 20px;
+  flex-wrap: wrap;
 }


### PR DESCRIPTION
This PR hopes to fix #19 

Added `flex-wrap: wrap` to the `.nav-menu` class to make it wrap on mobile devices

Thanks
